### PR TITLE
Add possibility to disable installation of dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Roche
 
 * `disable_install_dev_deps`:
 
-  _Description_: Disable installation of dev dependencies during running report.
+  _Description_: Disable installation of dev dependencies while building the report.
 
   _Required_: `false`
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Roche
 
 * `no_cache`:
 
-  _Description_: Disable github action R dependency caching
+  _Description_: Disable github action R dependency caching.
 
   _Required_: `false`
 
@@ -86,7 +86,15 @@ Roche
 
   _Required_: `false`
 
-  _Default_: `v1"`
+  _Default_: `v1`
+
+* `disable_install_dev_deps`:
+
+  _Description_: Disable installation of dev dependencies during running report.
+
+  _Required_: `false`
+
+  _Default_: `false`
 
 ### Outputs
 None

--- a/action.yml
+++ b/action.yml
@@ -34,8 +34,8 @@ inputs:
     default: "v1"
   disable_install_dev_deps:
     description: |
-      Disable installation of dev dependencies during
-      running report.
+      Disable installation of dev dependencies while
+      building the report.
     required: false
     default: "false"
 branding: # https://feathericons.com/

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,12 @@ inputs:
     description: "Version of the cache. To clean cache bump this version."
     required: false
     default: "v1"
+  disable_install_dev_deps:
+    description: |
+      Disable installation of dev dependencies during
+      running report.
+    required: false
+    default: "false"
 branding: # https://feathericons.com/
   icon: "award"
   color: "blue"
@@ -96,3 +102,4 @@ runs:
         INPUT_REPORT_PKG_DIR: ${{ inputs.report_pkg_dir }}
         INPUT_REPORT_TEMPLATE_PATH: ${{ inputs.report_template_path }}
         INPUT_REPORT_RMARKDOWN_FORMAT: ${{ inputs.report_rmarkdown_format }}
+        DISABLE_INSTALL_DEV_DEPS: ${{ inputs.disable_install_dev_deps }}

--- a/dependencies.R
+++ b/dependencies.R
@@ -13,6 +13,7 @@ lapply(github_packages, remotes::install_github)
 # CRAN
 options(repos = c("https://cloud.r-project.org/"))
 ncores <- parallel::detectCores(all.tests = FALSE, logical = TRUE)
+if (!require("git2r")) install.packages("git2r", upgrade = "never", Ncpus = ncores)
 if (!require("kableExtra")) install.packages("kableExtra", upgrade = "never", Ncpus = ncores)
 if (!require("tinytex")) install.packages("tinytex", upgrade = "never", Ncpus = ncores)
 


### PR DESCRIPTION
Fix issue related with installation packages from private repositories (missing auth token).

```
The downloaded source packages are in
	‘/tmp/Rtmpknn3ha/downloaded_packages’
Error: Failed to install 'unknown package' from Git:
  Error in 'git2r_remote_ls'
In addition: Warning messages:
1: In git2r::remote_ls(remote$url, credentials = remote$credentials) :
  Error in 'git2r_remote_ls'

2: In git2r::remote_ls(remote$url, credentials = remote$credentials) :
  Error in 'git2r_remote_ls'
```

Allow to disable installation of package dependencies by **thevalidatoR** if it's managed by other tool (like staged.dependencies).