### PR TITLE
Update tlmgr

### DIFF
--- a/dependencies.R
+++ b/dependencies.R
@@ -27,6 +27,7 @@ mkdir -p ${RUNNER_TEMP}/TinyTeX
 cp -r ~/.TinyTeX/. ${RUNNER_TEMP}/TinyTeX
 rm -rf ~/.TinyTeX
 ${RUNNER_TEMP}/TinyTeX/bin/*/tlmgr path add
+tlmgr update --self
 tlmgr install latex-bin luatex xetex ae bibtex context inconsolata listings makeindex metafont mfware parskip pdfcrop tex tools url xkeyval
 '
   # nolint end


### PR DESCRIPTION
Otherwise it fails with:

```
===============================================================================
tlmgr itself needs to be updated.
Please do this via either
  tlmgr update --self
or by getting the latest updater for Unix-ish systems:
  [mirror.ctan.org/systems/texlive/tlnet/update-tlmgr-latest.sh](https://mirror.ctan.org/systems/texlive/tlnet/update-tlmgr-latest.sh)
and/or Windows systems:
  [mirror.ctan.org/systems/texlive/tlnet/update-tlmgr-latest.exe](https://mirror.ctan.org/systems/texlive/tlnet/update-tlmgr-latest.exe)
Then continue with other updates as usual.
===============================================================================
tlmgr: Terminating; please see warning above!
```