### PR TITLE
Org names are case sensitive for older versions of `remotes`

### DIFF
--- a/dependencies.R
+++ b/dependencies.R
@@ -6,7 +6,7 @@
 github_packages <- c(
     "r-lib/covr",
     "pharmaR/riskmetric",
-    "genentech/covtracer"
+    "Genentech/covtracer"
 )
 lapply(github_packages, remotes::install_github)
 


### PR DESCRIPTION
Saw this for Admiral:

```
Error: Error: Failed to install 'unknown package' from GitHub:
  HTTP error 404.
  No commit found for the ref master

  Did you spell the repo owner (`genentech`) and repo name (`covtracer`) correctly?
  - If spelling is correct, check that you have the required permissions to access the repo.
Execution halted
```