### PR TITLE
continue on error

### DIFF
--- a/template.Rmd
+++ b/template.Rmd
@@ -35,6 +35,7 @@ library(magrittr)
 library(knitr)
 library(kableExtra)
 knitr::opts_chunk$set(
+  error = TRUE,
   width = 80L,
   comment = ""
 )


### PR DESCRIPTION
Add an option to continue on error (most likely: R CMD CHECK error) from [default false](https://yihui.org/knitr/options/#:~:text=Note%20that%20R%20Markdown%20has%20changed%20this%20default%20value%20to%20FALSE.) into true. This allows process to finish so that repo maintainers will see what's wrong in case of errors. For now, it's only this:

```
  |..........................................                            |  60%
label: r_cmd_check (with options) 
List of 2
 $ echo: logi FALSE
 $ eval: logi TRUE

Quitting from lines 160-172 (template.Rmd) 
```

There are multiple reports that this message is not really helpful.

This has a significant side effect that fail of R CMD CHECK will not fail the workflow anymore and the whole workflow will almost always succeed. My assumption is that CHECK is usually executed in a separate, obligatory workflow and validation is an optional artefact that would have to be investigated. Please share your thoughts if you strongly disagree with that. 

Workflow fail is definitely implementable but this would require changes in both validator and validator action. Validator would have to finish the process and _return_ the information about the failure to the action to pick up and fail (if needed).